### PR TITLE
Add FuseTanhInLinear transformation for nn.Linear and nn.Tanh fusion

### DIFF
--- a/optimum/fx/optimization/__init__.py
+++ b/optimum/fx/optimization/__init__.py
@@ -13,12 +13,12 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from .transformations import (  # noqa
-    ChangeTrueDivToMulByInverse,
-    FuseBatchNorm1dInLinear,
-    FuseBatchNorm2dInConv2d,
-    FuseBiasInLinear,
-    FuseTanhInLinear,
     MergeLinears,
+    FuseBiasInLinear,
+    ChangeTrueDivToMulByInverse,
+    FuseBatchNorm2dInConv2d,
+    FuseBatchNorm1dInLinear,
+    FuseTanhInLinear,
     ReversibleTransformation,
     Transformation,
     compose,

--- a/optimum/fx/optimization/__init__.py
+++ b/optimum/fx/optimization/__init__.py
@@ -17,6 +17,7 @@ from .transformations import (  # noqa
     FuseBatchNorm1dInLinear,
     FuseBatchNorm2dInConv2d,
     FuseBiasInLinear,
+    FuseTanhInLinear,
     MergeLinears,
     ReversibleTransformation,
     Transformation,


### PR DESCRIPTION
# What does this PR do?

- Create a optimum.fx.optimization transformation for nn.Linear and nn.Tanh fusion (**`FuseTanhInLinear`**).
- Create an unit test for **`FuseTanhInLinear`**.

Note that this PR can be refactored and extended to be more generic for torch.nn.Linear and activation functions (such as torch.nn.GELU, torch.nn,Sigmoid, and etc.).
